### PR TITLE
isMultipleOfSeventeenの実装

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,12 @@
 'use strict';
+/**
+ * 17の倍数である場合、trueを返す
+ * @param { number } num
+ */
+function isMultipleOfSeventeen( num ) {
+  return num % 17 === 0;
+}
 
 module.exports = {
-}
+  isMultipleOfSeventeen: isMultipleOfSeventeen
+};


### PR DESCRIPTION
test.jsでは `isMultipleOfSeventeen` なのに、問題文と回答例では `isSeventeen` になっている？