### PR TITLE
プルリクのテストなのでマージは不要です - 配列に含まれる整数が 17 で割り切れるものだけ

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,8 +1,12 @@
 'use strict';
-const seventeen = require('./index.js');
-const assert = require('assert');
+/**
+ * 17の倍数である場合 true を返す
+ * @param {number} num
+ */
+function isMultipleOfSeventeen(num) {
+  return num % 17 === 0;
+}
 
-const a = [83, 32, 85, 47, 77, 8, 61, 74, 29, 34, 11, 76, 60, 99, 55, 7, 19, 60, 98, 38, 28, 96, 32];
-assert.deepEqual(a.filter(seventeen.isMultipleOfSeventeen), [85, 34]);
-
-console.log('テストが正常に完了しました');
+module.exports = {
+  isMultipleOfSeventeen
+};


### PR DESCRIPTION
プルリクのテストなのでマージは不要です

配列に含まれる整数が 17 で割り切れるものだけにする seventeen モジュールを実装しようとしています。
そのために、整数が 17 で割り切れるかどうかを判定する isMultipleOfSeventeen 関数を seventeen モジュールに実装してください。